### PR TITLE
Fix options to be camel case

### DIFF
--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -60,16 +60,16 @@ type config struct {
 	Brokers       []string `json:"brokers" mapstructure:"brokers" envconfig:"K6_KAFKA_BROKERS"`
 	Topic         string   `json:"topic" mapstructure:"topic" envconfig:"K6_KAFKA_TOPIC"`
 	Format        string   `json:"format" mapstructure:"format" envconfig:"K6_KAFKA_FORMAT"`
-	PushInterval  string   `json:"pushInterval" mapstructure:"push_interval" envconfig:"K6_KAFKA_PUSH_INTERVAL"`
+	PushInterval  string   `json:"pushInterval" mapstructure:"pushInterval" envconfig:"K6_KAFKA_PUSH_INTERVAL"`
 	User          string   `json:"user" mapstructure:"user" envconfig:"K6_KAFKA_SASL_USER"`
 	Password      string   `json:"password" mapstructure:"password" envconfig:"K6_KAFKA_SASL_PASSWORD"`
-	AuthMechanism string   `json:"authMechanism" mapstructure:"auth_mechanism" envconfig:"K6_KAFKA_AUTH_MECHANISM"`
+	AuthMechanism string   `json:"authMechanism" mapstructure:"authMechanism" envconfig:"K6_KAFKA_AUTH_MECHANISM"`
 
 	InfluxDBConfig influxdbConfig `json:"influxdb" mapstructure:"influxdb"`
 	Version        string         `json:"version" mapstructure:"version"`
 	SSL            bool           `json:"ssl" mapstructure:"ssl"`
 	Insecure       bool           `json:"insecure" mapstructure:"insecure"`
-	LogError       bool           `json:"logError" mapstructure:"log_error"`
+	LogError       bool           `json:"logError" mapstructure:"logError"`
 }
 
 // NewConfig creates a new Config instance with default values for some fields.
@@ -149,7 +149,7 @@ func ParseArg(arg string) (Config, error) {
 
 	delete(params, "influxdb")
 
-	if v, ok := params["push_interval"].(string); ok {
+	if v, ok := params["pushInterval"].(string); ok {
 		err := c.PushInterval.UnmarshalText([]byte(v))
 		if err != nil {
 			return c, err
@@ -164,15 +164,15 @@ func ParseArg(arg string) (Config, error) {
 		c.SSL = null.BoolFrom(v)
 	}
 
-	if v, ok := params["skip_cert_verify"].(bool); ok {
+	if v, ok := params["insecure"].(bool); ok {
 		c.Insecure = null.BoolFrom(v)
 	}
 
-	if v, ok := params["log_error"].(bool); ok {
+	if v, ok := params["logError"].(bool); ok {
 		c.LogError = null.BoolFrom(v)
 	}
 
-	if v, ok := params["auth_mechanism"].(string); ok {
+	if v, ok := params["authMechanism"].(string); ok {
 		c.AuthMechanism = null.StringFrom(v)
 	}
 

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -40,16 +40,16 @@ type Config struct {
 	Brokers []string `json:"brokers" envconfig:"K6_KAFKA_BROKERS"`
 
 	// Samples.
-	Topic         null.String        `json:"topic" envconfig:"K6_KAFKA_TOPIC"`
-	User          null.String        `json:"user" envconfig:"K6_KAFKA_SASL_USER"`
-	Password      null.String        `json:"password" envconfig:"K6_KAFKA_SASL_PASSWORD"`
-	AuthMechanism null.String        `json:"authMechanism" envconfig:"K6_KAFKA_AUTH_MECHANISM"`
-	Format        null.String        `json:"format" envconfig:"K6_KAFKA_FORMAT"`
-	PushInterval  types.NullDuration `json:"pushInterval" envconfig:"K6_KAFKA_PUSH_INTERVAL"`
-	Version       null.String        `json:"version" envconfig:"K6_KAFKA_VERSION"`
-	SSL           null.Bool          `json:"ssl" envconfig:"K6_KAFKA_SSL"`
-	Insecure      null.Bool          `json:"insecure" envconfig:"K6_KAFKA_INSECURE"`
-	LogError      null.Bool          `json:"logError" envconfig:"K6_KAFKA_LOG_ERROR"`
+	Topic                 null.String        `json:"topic" envconfig:"K6_KAFKA_TOPIC"`
+	User                  null.String        `json:"user" envconfig:"K6_KAFKA_SASL_USER"`
+	Password              null.String        `json:"password" envconfig:"K6_KAFKA_SASL_PASSWORD"`
+	AuthMechanism         null.String        `json:"authMechanism" envconfig:"K6_KAFKA_AUTH_MECHANISM"`
+	Format                null.String        `json:"format" envconfig:"K6_KAFKA_FORMAT"`
+	PushInterval          types.NullDuration `json:"pushInterval" envconfig:"K6_KAFKA_PUSH_INTERVAL"`
+	Version               null.String        `json:"version" envconfig:"K6_KAFKA_VERSION"`
+	SSL                   null.Bool          `json:"ssl" envconfig:"K6_KAFKA_SSL"`
+	InsecureSkipTLSVerify null.Bool          `json:"insecureSkipTLSVerify" envconfig:"K6_KAFKA_INSECURE_SKIP_TLS_VERIFY"`
+	LogError              null.Bool          `json:"logError" envconfig:"K6_KAFKA_LOG_ERROR"`
 
 	InfluxDBConfig influxdbConfig `json:"influxdb"`
 }
@@ -68,21 +68,21 @@ type config struct {
 	InfluxDBConfig influxdbConfig `json:"influxdb" mapstructure:"influxdb"`
 	Version        string         `json:"version" mapstructure:"version"`
 	SSL            bool           `json:"ssl" mapstructure:"ssl"`
-	Insecure       bool           `json:"insecure" mapstructure:"insecure"`
+	Insecure       bool           `json:"insecureSkipTLSVerify" mapstructure:"insecure"`
 	LogError       bool           `json:"logError" mapstructure:"logError"`
 }
 
 // NewConfig creates a new Config instance with default values for some fields.
 func NewConfig() Config {
 	return Config{
-		Format:         null.StringFrom("json"),
-		PushInterval:   types.NullDurationFrom(1 * time.Second),
-		InfluxDBConfig: newInfluxdbConfig(),
-		AuthMechanism:  null.StringFrom("none"),
-		Version:        null.StringFrom(sarama.DefaultVersion.String()),
-		SSL:            null.BoolFrom(false),
-		Insecure:       null.BoolFrom(false),
-		LogError:       null.BoolFrom(true),
+		Format:                null.StringFrom("json"),
+		PushInterval:          types.NullDurationFrom(1 * time.Second),
+		InfluxDBConfig:        newInfluxdbConfig(),
+		AuthMechanism:         null.StringFrom("none"),
+		Version:               null.StringFrom(sarama.DefaultVersion.String()),
+		SSL:                   null.BoolFrom(false),
+		InsecureSkipTLSVerify: null.BoolFrom(false),
+		LogError:              null.BoolFrom(true),
 	}
 }
 
@@ -115,8 +115,8 @@ func (c Config) Apply(cfg Config) Config {
 		c.SSL = cfg.SSL
 	}
 
-	if cfg.Insecure.Valid {
-		c.Insecure = cfg.Insecure
+	if cfg.InsecureSkipTLSVerify.Valid {
+		c.InsecureSkipTLSVerify = cfg.InsecureSkipTLSVerify
 	}
 
 	if cfg.LogError.Valid {
@@ -164,8 +164,8 @@ func ParseArg(arg string) (Config, error) {
 		c.SSL = null.BoolFrom(v)
 	}
 
-	if v, ok := params["insecure"].(bool); ok {
-		c.Insecure = null.BoolFrom(v)
+	if v, ok := params["insecureSkipTLSVerify"].(bool); ok {
+		c.InsecureSkipTLSVerify = null.BoolFrom(v)
 	}
 
 	if v, ok := params["logError"].(bool); ok {

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -43,13 +43,13 @@ type Config struct {
 	Topic         null.String        `json:"topic" envconfig:"K6_KAFKA_TOPIC"`
 	User          null.String        `json:"user" envconfig:"K6_KAFKA_SASL_USER"`
 	Password      null.String        `json:"password" envconfig:"K6_KAFKA_SASL_PASSWORD"`
-	AuthMechanism null.String        `json:"auth_mechanism" envconfig:"K6_KAFKA_AUTH_MECHANISM"`
+	AuthMechanism null.String        `json:"authMechanism" envconfig:"K6_KAFKA_AUTH_MECHANISM"`
 	Format        null.String        `json:"format" envconfig:"K6_KAFKA_FORMAT"`
-	PushInterval  types.NullDuration `json:"push_interval" envconfig:"K6_KAFKA_PUSH_INTERVAL"`
+	PushInterval  types.NullDuration `json:"pushInterval" envconfig:"K6_KAFKA_PUSH_INTERVAL"`
 	Version       null.String        `json:"version" envconfig:"K6_KAFKA_VERSION"`
 	SSL           null.Bool          `json:"ssl" envconfig:"K6_KAFKA_SSL"`
 	Insecure      null.Bool          `json:"insecure" envconfig:"K6_KAFKA_INSECURE"`
-	LogError      null.Bool          `json:"log_error" envconfig:"K6_KAFKA_LOG_ERROR"`
+	LogError      null.Bool          `json:"logError" envconfig:"K6_KAFKA_LOG_ERROR"`
 
 	InfluxDBConfig influxdbConfig `json:"influxdb"`
 }
@@ -60,16 +60,16 @@ type config struct {
 	Brokers       []string `json:"brokers" mapstructure:"brokers" envconfig:"K6_KAFKA_BROKERS"`
 	Topic         string   `json:"topic" mapstructure:"topic" envconfig:"K6_KAFKA_TOPIC"`
 	Format        string   `json:"format" mapstructure:"format" envconfig:"K6_KAFKA_FORMAT"`
-	PushInterval  string   `json:"push_interval" mapstructure:"push_interval" envconfig:"K6_KAFKA_PUSH_INTERVAL"`
+	PushInterval  string   `json:"pushInterval" mapstructure:"push_interval" envconfig:"K6_KAFKA_PUSH_INTERVAL"`
 	User          string   `json:"user" mapstructure:"user" envconfig:"K6_KAFKA_SASL_USER"`
 	Password      string   `json:"password" mapstructure:"password" envconfig:"K6_KAFKA_SASL_PASSWORD"`
-	AuthMechanism string   `json:"auth_mechanism" mapstructure:"auth_mechanism" envconfig:"K6_KAFKA_AUTH_MECHANISM"`
+	AuthMechanism string   `json:"authMechanism" mapstructure:"auth_mechanism" envconfig:"K6_KAFKA_AUTH_MECHANISM"`
 
 	InfluxDBConfig influxdbConfig `json:"influxdb" mapstructure:"influxdb"`
 	Version        string         `json:"version" mapstructure:"version"`
 	SSL            bool           `json:"ssl" mapstructure:"ssl"`
 	Insecure       bool           `json:"insecure" mapstructure:"insecure"`
-	LogError       bool           `json:"log_error" mapstructure:"log_error"`
+	LogError       bool           `json:"logError" mapstructure:"log_error"`
 }
 
 // NewConfig creates a new Config instance with default values for some fields.

--- a/pkg/kafka/config_test.go
+++ b/pkg/kafka/config_test.go
@@ -69,7 +69,7 @@ func TestConfigParseArg(t *testing.T) {
 	assert.Equal(t, null.StringFrom("influxdb"), c.Format)
 	assert.Equal(t, expInfluxConfig, c.InfluxDBConfig)
 
-	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,auth_mechanism=SASL_PLAINTEXT,user=johndoe,password=123password")
+	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,authMechanism=SASL_PLAINTEXT,user=johndoe,password=123password")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"broker2", "broker3:9092"}, c.Brokers)
 	assert.Equal(t, null.StringFrom("someTopic"), c.Topic)
@@ -79,7 +79,7 @@ func TestConfigParseArg(t *testing.T) {
 	assert.Equal(t, null.StringFrom("123password"), c.Password)
 	assert.Equal(t, null.NewBool(false, false), c.SSL)
 
-	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,auth_mechanism=SASL_PLAINTEXT,user=johndoe,password=123password,ssl=false")
+	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,authMechanism=SASL_PLAINTEXT,user=johndoe,password=123password,ssl=false")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"broker2", "broker3:9092"}, c.Brokers)
 	assert.Equal(t, null.StringFrom("someTopic"), c.Topic)
@@ -90,7 +90,7 @@ func TestConfigParseArg(t *testing.T) {
 	assert.Equal(t, null.BoolFrom(false), c.SSL)
 	assert.Equal(t, null.NewBool(false, false), c.Insecure)
 
-	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,auth_mechanism=SASL_PLAINTEXT,user=johndoe,password=123password,ssl=true")
+	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,authMechanism=SASL_PLAINTEXT,user=johndoe,password=123password,ssl=true")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"broker2", "broker3:9092"}, c.Brokers)
 	assert.Equal(t, null.StringFrom("someTopic"), c.Topic)
@@ -101,7 +101,7 @@ func TestConfigParseArg(t *testing.T) {
 	assert.Equal(t, null.BoolFrom(true), c.SSL)
 	assert.Equal(t, null.NewBool(false, false), c.Insecure)
 
-	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,auth_mechanism=SASL_PLAINTEXT,user=johndoe,password=123password,ssl=true,skip_cert_verify=true")
+	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,authMechanism=SASL_PLAINTEXT,user=johndoe,password=123password,ssl=true,insecure=true")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"broker2", "broker3:9092"}, c.Brokers)
 	assert.Equal(t, null.StringFrom("someTopic"), c.Topic)
@@ -112,7 +112,7 @@ func TestConfigParseArg(t *testing.T) {
 	assert.Equal(t, null.BoolFrom(true), c.Insecure)
 	assert.Equal(t, null.NewBool(false, false), c.LogError)
 
-	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,auth_mechanism=SASL_PLAINTEXT,user=johndoe,password=123password,log_error=true")
+	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,authMechanism=SASL_PLAINTEXT,user=johndoe,password=123password,logError=true")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"broker2", "broker3:9092"}, c.Brokers)
 	assert.Equal(t, null.StringFrom("someTopic"), c.Topic)
@@ -121,7 +121,7 @@ func TestConfigParseArg(t *testing.T) {
 	assert.Equal(t, null.StringFrom("johndoe"), c.User)
 	assert.Equal(t, null.BoolFrom(true), c.LogError)
 
-	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,auth_mechanism=SASL_PLAINTEXT,user=johndoe,password=123password,log_error=false")
+	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,authMechanism=SASL_PLAINTEXT,user=johndoe,password=123password,logError=false")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"broker2", "broker3:9092"}, c.Brokers)
 	assert.Equal(t, null.StringFrom("someTopic"), c.Topic)
@@ -240,7 +240,7 @@ func TestConsolidatedConfig(t *testing.T) {
 			},
 			err: "user and password are required when auth mechanism is provided",
 		},
-		"disable_log_error": {
+		"disable_logError": {
 			env: map[string]string{
 				"K6_KAFKA_AUTH_MECHANISM": "none",
 				"K6_KAFKA_LOG_ERROR":      "false",

--- a/pkg/kafka/config_test.go
+++ b/pkg/kafka/config_test.go
@@ -88,7 +88,7 @@ func TestConfigParseArg(t *testing.T) {
 	assert.Equal(t, null.StringFrom("johndoe"), c.User)
 	assert.Equal(t, null.StringFrom("123password"), c.Password)
 	assert.Equal(t, null.BoolFrom(false), c.SSL)
-	assert.Equal(t, null.NewBool(false, false), c.Insecure)
+	assert.Equal(t, null.NewBool(false, false), c.InsecureSkipTLSVerify)
 
 	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,authMechanism=SASL_PLAINTEXT,user=johndoe,password=123password,ssl=true")
 	assert.Nil(t, err)
@@ -99,9 +99,9 @@ func TestConfigParseArg(t *testing.T) {
 	assert.Equal(t, null.StringFrom("johndoe"), c.User)
 	assert.Equal(t, null.StringFrom("123password"), c.Password)
 	assert.Equal(t, null.BoolFrom(true), c.SSL)
-	assert.Equal(t, null.NewBool(false, false), c.Insecure)
+	assert.Equal(t, null.NewBool(false, false), c.InsecureSkipTLSVerify)
 
-	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,authMechanism=SASL_PLAINTEXT,user=johndoe,password=123password,ssl=true,insecure=true")
+	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,authMechanism=SASL_PLAINTEXT,user=johndoe,password=123password,ssl=true,insecureSkipTLSVerify=true")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"broker2", "broker3:9092"}, c.Brokers)
 	assert.Equal(t, null.StringFrom("someTopic"), c.Topic)
@@ -109,7 +109,7 @@ func TestConfigParseArg(t *testing.T) {
 	assert.Equal(t, null.StringFrom("SASL_PLAINTEXT"), c.AuthMechanism)
 	assert.Equal(t, null.StringFrom("johndoe"), c.User)
 	assert.Equal(t, null.BoolFrom(true), c.SSL)
-	assert.Equal(t, null.BoolFrom(true), c.Insecure)
+	assert.Equal(t, null.BoolFrom(true), c.InsecureSkipTLSVerify)
 	assert.Equal(t, null.NewBool(false, false), c.LogError)
 
 	c, err = ParseArg("brokers={broker2,broker3:9092},topic=someTopic,format=json,authMechanism=SASL_PLAINTEXT,user=johndoe,password=123password,logError=true")
@@ -146,26 +146,26 @@ func TestConsolidatedConfig(t *testing.T) {
 				"K6_KAFKA_AUTH_MECHANISM": "none",
 			},
 			config: Config{
-				Format:         null.StringFrom("json"),
-				PushInterval:   types.NullDurationFrom(1 * time.Second),
-				InfluxDBConfig: newInfluxdbConfig(),
-				AuthMechanism:  null.StringFrom("none"),
-				Version:        null.StringFrom(sarama.DefaultVersion.String()),
-				SSL:            null.BoolFrom(false),
-				Insecure:       null.BoolFrom(false),
-				LogError:       null.BoolFrom(true),
+				Format:                null.StringFrom("json"),
+				PushInterval:          types.NullDurationFrom(1 * time.Second),
+				InfluxDBConfig:        newInfluxdbConfig(),
+				AuthMechanism:         null.StringFrom("none"),
+				Version:               null.StringFrom(sarama.DefaultVersion.String()),
+				SSL:                   null.BoolFrom(false),
+				InsecureSkipTLSVerify: null.BoolFrom(false),
+				LogError:              null.BoolFrom(true),
 			},
 		},
 		"ssl-true-through-env": {
 			config: Config{
-				Format:         null.StringFrom("json"),
-				PushInterval:   types.NullDurationFrom(1 * time.Second),
-				InfluxDBConfig: newInfluxdbConfig(),
-				AuthMechanism:  null.StringFrom("none"),
-				Version:        null.StringFrom(sarama.DefaultVersion.String()),
-				SSL:            null.BoolFrom(true),
-				Insecure:       null.BoolFrom(false),
-				LogError:       null.BoolFrom(true),
+				Format:                null.StringFrom("json"),
+				PushInterval:          types.NullDurationFrom(1 * time.Second),
+				InfluxDBConfig:        newInfluxdbConfig(),
+				AuthMechanism:         null.StringFrom("none"),
+				Version:               null.StringFrom(sarama.DefaultVersion.String()),
+				SSL:                   null.BoolFrom(true),
+				InsecureSkipTLSVerify: null.BoolFrom(false),
+				LogError:              null.BoolFrom(true),
 			},
 			env: map[string]string{
 				"K6_KAFKA_SSL": "true",
@@ -178,16 +178,16 @@ func TestConsolidatedConfig(t *testing.T) {
 				"K6_KAFKA_SASL_USER":      "testuser",
 			},
 			config: Config{
-				Format:         null.StringFrom("json"),
-				PushInterval:   types.NullDurationFrom(1 * time.Second),
-				InfluxDBConfig: newInfluxdbConfig(),
-				AuthMechanism:  null.StringFrom("scram-sha-512"),
-				Password:       null.StringFrom("password123"),
-				User:           null.StringFrom("testuser"),
-				Version:        null.StringFrom(sarama.DefaultVersion.String()),
-				SSL:            null.BoolFrom(false),
-				Insecure:       null.BoolFrom(false),
-				LogError:       null.BoolFrom(true),
+				Format:                null.StringFrom("json"),
+				PushInterval:          types.NullDurationFrom(1 * time.Second),
+				InfluxDBConfig:        newInfluxdbConfig(),
+				AuthMechanism:         null.StringFrom("scram-sha-512"),
+				Password:              null.StringFrom("password123"),
+				User:                  null.StringFrom("testuser"),
+				Version:               null.StringFrom(sarama.DefaultVersion.String()),
+				SSL:                   null.BoolFrom(false),
+				InsecureSkipTLSVerify: null.BoolFrom(false),
+				LogError:              null.BoolFrom(true),
 			},
 		},
 		"auth-missing-credentials": {
@@ -195,14 +195,14 @@ func TestConsolidatedConfig(t *testing.T) {
 				"K6_KAFKA_AUTH_MECHANISM": "scram-sha-512",
 			},
 			config: Config{
-				Format:         null.StringFrom("json"),
-				PushInterval:   types.NullDurationFrom(1 * time.Second),
-				InfluxDBConfig: newInfluxdbConfig(),
-				AuthMechanism:  null.StringFrom("scram-sha-512"),
-				Version:        null.StringFrom(sarama.DefaultVersion.String()),
-				SSL:            null.BoolFrom(false),
-				Insecure:       null.BoolFrom(false),
-				LogError:       null.BoolFrom(true),
+				Format:                null.StringFrom("json"),
+				PushInterval:          types.NullDurationFrom(1 * time.Second),
+				InfluxDBConfig:        newInfluxdbConfig(),
+				AuthMechanism:         null.StringFrom("scram-sha-512"),
+				Version:               null.StringFrom(sarama.DefaultVersion.String()),
+				SSL:                   null.BoolFrom(false),
+				InsecureSkipTLSVerify: null.BoolFrom(false),
+				LogError:              null.BoolFrom(true),
 			},
 			err: "user and password are required when auth mechanism is provided",
 		},
@@ -212,14 +212,14 @@ func TestConsolidatedConfig(t *testing.T) {
 				"K6_KAFKA_SASL_PASSWORD":  "password123",
 			},
 			config: Config{
-				Format:         null.StringFrom("json"),
-				PushInterval:   types.NullDurationFrom(1 * time.Second),
-				InfluxDBConfig: newInfluxdbConfig(),
-				AuthMechanism:  null.StringFrom("scram-sha-512"),
-				Version:        null.StringFrom(sarama.DefaultVersion.String()),
-				SSL:            null.BoolFrom(false),
-				Insecure:       null.BoolFrom(false),
-				LogError:       null.BoolFrom(true),
+				Format:                null.StringFrom("json"),
+				PushInterval:          types.NullDurationFrom(1 * time.Second),
+				InfluxDBConfig:        newInfluxdbConfig(),
+				AuthMechanism:         null.StringFrom("scram-sha-512"),
+				Version:               null.StringFrom(sarama.DefaultVersion.String()),
+				SSL:                   null.BoolFrom(false),
+				InsecureSkipTLSVerify: null.BoolFrom(false),
+				LogError:              null.BoolFrom(true),
 			},
 			err: "user and password are required when auth mechanism is provided",
 		},
@@ -229,14 +229,14 @@ func TestConsolidatedConfig(t *testing.T) {
 				"K6_KAFKA_SASL_USER":      "testuser",
 			},
 			config: Config{
-				Format:         null.StringFrom("json"),
-				PushInterval:   types.NullDurationFrom(1 * time.Second),
-				InfluxDBConfig: newInfluxdbConfig(),
-				AuthMechanism:  null.StringFrom("scram-sha-512"),
-				Version:        null.StringFrom(sarama.DefaultVersion.String()),
-				SSL:            null.BoolFrom(false),
-				Insecure:       null.BoolFrom(false),
-				LogError:       null.BoolFrom(true),
+				Format:                null.StringFrom("json"),
+				PushInterval:          types.NullDurationFrom(1 * time.Second),
+				InfluxDBConfig:        newInfluxdbConfig(),
+				AuthMechanism:         null.StringFrom("scram-sha-512"),
+				Version:               null.StringFrom(sarama.DefaultVersion.String()),
+				SSL:                   null.BoolFrom(false),
+				InsecureSkipTLSVerify: null.BoolFrom(false),
+				LogError:              null.BoolFrom(true),
 			},
 			err: "user and password are required when auth mechanism is provided",
 		},
@@ -246,14 +246,14 @@ func TestConsolidatedConfig(t *testing.T) {
 				"K6_KAFKA_LOG_ERROR":      "false",
 			},
 			config: Config{
-				Format:         null.StringFrom("json"),
-				PushInterval:   types.NullDurationFrom(1 * time.Second),
-				InfluxDBConfig: newInfluxdbConfig(),
-				AuthMechanism:  null.StringFrom("none"),
-				Version:        null.StringFrom(sarama.DefaultVersion.String()),
-				SSL:            null.BoolFrom(false),
-				Insecure:       null.BoolFrom(false),
-				LogError:       null.BoolFrom(false),
+				Format:                null.StringFrom("json"),
+				PushInterval:          types.NullDurationFrom(1 * time.Second),
+				InfluxDBConfig:        newInfluxdbConfig(),
+				AuthMechanism:         null.StringFrom("none"),
+				Version:               null.StringFrom(sarama.DefaultVersion.String()),
+				SSL:                   null.BoolFrom(false),
+				InsecureSkipTLSVerify: null.BoolFrom(false),
+				LogError:              null.BoolFrom(false),
 			},
 		},
 	}

--- a/pkg/kafka/output.go
+++ b/pkg/kafka/output.go
@@ -83,7 +83,7 @@ func newProducer(config Config) (sarama.AsyncProducer, error) {
 		if config.SSL.Bool {
 			saramaConfig.Net.TLS.Enable = true
 			saramaConfig.Net.TLS.Config = &tls.Config{
-				InsecureSkipVerify: config.Insecure.Bool,
+				InsecureSkipVerify: config.InsecureSkipTLSVerify.Bool,
 				ClientAuth:         0,
 			}
 		}


### PR DESCRIPTION
This is a bit of breaking change between what was previously, but it makes things consistent and I would argue there are probably not that many people apart from @knmsk and @victorlcm who are using it and hopefully they agree that changing the configuration to be consistent with what is mostly in k6 is better done now :).

I mostly wonder if it won't be better to rename `insecure` to `skipCertVerify`?