### PR TITLE
Feat/expose real metric type

### DIFF
--- a/pkg/kafka/format_json.go
+++ b/pkg/kafka/format_json.go
@@ -30,7 +30,7 @@ import (
 // to JSON.
 func wrapSample(sample metrics.Sample) envelope {
 	return envelope{
-		Type:   "Point",
+		Type:   sample.Metric.Type.String(),
 		Metric: sample.Metric.Name,
 		Data:   newJSONSample(sample),
 	}

--- a/pkg/kafka/output_test.go
+++ b/pkg/kafka/output_test.go
@@ -90,9 +90,11 @@ func TestFormatSample(t *testing.T) {
 
 	o.Config.Format = null.NewString("json", false)
 	formattedSamples, err = o.formatSamples(samples)
+	
+	gaugeMetric := metrics.Gauge.String()
 
-	expJSON1 := "{\"type\":\"Point\",\"data\":{\"time\":\"0001-01-01T00:00:00Z\",\"value\":1.25,\"tags\":{\"a\":\"1\"}},\"metric\":\"my_metric\"}"
-	expJSON2 := "{\"type\":\"Point\",\"data\":{\"time\":\"0001-01-01T00:00:00Z\",\"value\":2,\"tags\":{\"b\":\"2\"}},\"metric\":\"my_metric\"}"
+	expJSON1 := "{\"type\":\"" + gaugeMetric + "\",\"data\":{\"time\":\"0001-01-01T00:00:00Z\",\"value\":1.25,\"tags\":{\"a\":\"1\"}},\"metric\":\"my_metric\"}"
+	expJSON2 := "{\"type\":\"" + gaugeMetric + "\",\"data\":{\"time\":\"0001-01-01T00:00:00Z\",\"value\":2,\"tags\":{\"b\":\"2\"}},\"metric\":\"my_metric\"}"
 
 	assert.Nil(t, err)
 	assert.Equal(t, []string{expJSON1, expJSON2}, formattedSamples)


### PR DESCRIPTION
I was comparing the output of this extension and statsd output and i descovered that the exported type of metrics with the `xk6-output-kafka` is not the real metric type. Does it makes sense?